### PR TITLE
Bump zk dependency 1.9 -> 1.10 to get version of zookeeper that builds for me

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,13 @@ Druid::Query::Builder.new.filter{dimension => 1, dimension1 =>2, dimension2 => 3
 Druid::Query::Builder.new.filter{dimension.eq(1) & dimension1.eq(2) & dimension2.eq(3)}
 ```
 
+## Instrumentation
+
+Provides a single event `post.druid`. Payload:
+
+ - `data_source`
+ - `query`
+
 ## Contributing
 
 1. Fork it

--- a/lib/druid/filter.rb
+++ b/lib/druid/filter.rb
@@ -328,14 +328,14 @@ module Druid
   class SearchFilter < Filter
     include BooleanOperators
 
-    def initialize(dimension, value)
+    def initialize(dimension, params)
       super()
       @type = 'search'
       @dimension = dimension
       @query = {
         type: 'contains',
-        value: value,
-        caseSensitive: true
+        value: params[:value],
+        caseSensitive: params[:case_sensitive] || false
       }
     end
   end

--- a/lib/druid/filter.rb
+++ b/lib/druid/filter.rb
@@ -166,6 +166,14 @@ module Druid
       CircFilter.new(@dimension, bounds)
     end
 
+    def bound(params)
+      BoundFilter.new(@dimension, params)
+    end
+
+    def search(params)
+      SearchFilter.new(@dimension, params)
+    end
+
     def eq(value)
       case value
       when ::Array
@@ -299,7 +307,35 @@ module Druid
       @bound = {
         type: 'radius',
         coords: bounds.first,
-        radius: bounds.last,
+        radius: bounds.last
+      }
+    end
+  end
+
+  class BoundFilter < Filter
+    include BooleanOperators
+
+    def initialize(dimension, params)
+      super()
+      @type = 'bound'
+      @dimension = dimension
+      @ordering = params[:ordering]
+      @upper = params[:upper]
+      @upperStrict = params[:upperStrict]
+    end
+  end
+
+  class SearchFilter < Filter
+    include BooleanOperators
+
+    def initialize(dimension, value)
+      super()
+      @type = 'search'
+      @dimension = dimension
+      @query = {
+        type: 'contains',
+        value: value,
+        caseSensitive: true
       }
     end
   end

--- a/lib/druid/version.rb
+++ b/lib/druid/version.rb
@@ -1,3 +1,3 @@
 module Druid
-  VERSION = '0.11.1'
+  VERSION = '0.11.3'
 end

--- a/lib/druid/version.rb
+++ b/lib/druid/version.rb
@@ -1,3 +1,3 @@
 module Druid
-  VERSION = '0.10.2'
+  VERSION = '0.11.2'
 end

--- a/lib/druid/version.rb
+++ b/lib/druid/version.rb
@@ -1,3 +1,3 @@
 module Druid
-  VERSION = '0.11.2'
+  VERSION = '0.11.1'
 end

--- a/ruby-druid.gemspec
+++ b/ruby-druid.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multi_json", "~> 1.0"
   spec.add_dependency "rest-client", ">= 1.8", "< 3.0"
   spec.add_dependency "zk", "~> 1.9"
-  spec.add_development_dependency "bundler", ">= 1.3.0", "< 2.0"
+  spec.add_development_dependency "bundler", ">= 1.3.0", "< 2.2"
   spec.add_development_dependency "rake", "~> 11.2"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "webmock", "~> 2.1"


### PR DESCRIPTION
I was trying to `bundle install` our `api` app (M1 MacBook), but it was failing to build a gem: `zookeeper` 1.4.11.

We depend on that via `ruby-druid` which points to `zk` 1.9 which points to `zookeeper` 1.4.11.

If I point `ruby-druid` at `zk` 1.10, I get `zookeeper` 1.15.0, which builds successfully.

I'm pointing my `api` Gemfile at this branch with:
```diff
-gem 'ruby-druid', '~> 0.11.3'
+gem 'ruby-druid', git: 'ssh://git@github.com/remerge/ruby-druid.git', ref: 'a1c2fdd44963ab859b1b975cbb8527047f764106'
```